### PR TITLE
fix frozen string bug

### DIFF
--- a/lib/serenity/escape_xml.rb
+++ b/lib/serenity/escape_xml.rb
@@ -4,14 +4,18 @@ class String
   end
 
   def convert_newlines
-    gsub!("\n", '<text:line-break/>')
+    if not self.frozen?
+      gsub!("\n", '<text:line-break/>')
+    end
     self
   end
 
   def mgsub!(key_value_pairs=[].freeze)
     regexp_fragments = key_value_pairs.collect { |k,v| k }
-    gsub!(Regexp.union(*regexp_fragments)) do |match|
-      key_value_pairs.detect{|k,v| k =~ match}[1]
+    if not self.frozen?
+      gsub!(Regexp.union(*regexp_fragments)) do |match|
+        key_value_pairs.detect{|k,v| k =~ match}[1]
+      end
     end
     self
   end


### PR DESCRIPTION
on Ruby 2.7 + was erroring on `FrozenError: can't modify frozen String: ""` so this is a quick fix for it. I suggest doing something else instead of gsub! to itself, but i don't wanna dive deeper into this